### PR TITLE
skip: fix pointer

### DIFF
--- a/src/cursor.v
+++ b/src/cursor.v
@@ -59,6 +59,7 @@ pub fn (cursor &C.mongoc_cursor_t) skip(skip int) &C.mongoc_cursor_t {
 		return unsafe { cursor }
 	}
 
+	// Do not free this document, it's used with whe cursor and used with the pointer of the current document of the cursor
 	mut document := &C.bson_t{}
 
 	mut count := skip

--- a/src/cursor.v
+++ b/src/cursor.v
@@ -68,9 +68,6 @@ pub fn (cursor &C.mongoc_cursor_t) skip(skip int) &C.mongoc_cursor_t {
 			break
 		}
 	}
-	unsafe {
-		document.destroy()
-	}
 	// // FIXME - it not possible set limit after .skip()
 	// unsafe{println("Set try >>>>>>>>>>> ${C.mongoc_cursor_set_limit(cursor, 1)}")}
 


### PR DESCRIPTION
Fixes the pointer of document in skip function, if we free the document in the function we can not work with them, it's used to work with the document outside the function.